### PR TITLE
Add metrics for idle queries and aggregate error rates

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
@@ -42,13 +42,17 @@ public class ConsumerCollector implements MetricCollector {
   private final Map<String, TopicSensors> topicSensors = new HashMap<>();
   private Metrics metrics;
   private String id;
+  private String groupId;
   private Time time;
 
   public void configure(Map<String, ?> map) {
     String id = (String) map.get(ConsumerConfig.GROUP_ID_CONFIG);
+    if (id != null) {
+      this.groupId = id;
+    }
     if (id == null) id = (String) map.get(ConsumerConfig.CLIENT_ID_CONFIG);
     if (id.contains(""))
-    configure(MetricCollectors.getMetrics(), MetricCollectors.addCollector(id, this), MetricCollectors.getTime());
+      configure(MetricCollectors.getMetrics(), MetricCollectors.addCollector(id, this), MetricCollectors.getTime());
   }
 
   ConsumerCollector configure(final Metrics metrics, final String id, final Time time) {
@@ -56,6 +60,11 @@ public class ConsumerCollector implements MetricCollector {
     this.metrics = metrics;
     this.time = time;
     return this;
+  }
+
+  @Override
+  public String getGroupId() {
+    return this.groupId;
   }
 
   @Override

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
@@ -41,6 +41,10 @@ interface MetricCollector extends ConsumerInterceptor, ProducerInterceptor {
 
   default void configure(Map<String, ?> map) {  }
 
+  default String getGroupId() {
+    return null;
+  }
+
   String getId();
 
   Collection<TopicSensors.Stat> stats(String topic, boolean isError);

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
@@ -51,6 +51,8 @@ interface MetricCollector extends ConsumerInterceptor, ProducerInterceptor {
 
   void recordError(String topic);
 
+  double errorRate();
+
   /**
    * Get the current message production across all topics tracked by this collector.
    */

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Topic based collectors for producer/consumer related statistics that can be mapped on to streams/tables/queries for ksql entities (Stream, Table, Query)
@@ -90,6 +91,16 @@ public class MetricCollectors {
     stats.forEach(stat -> results.append(stat.formatted()).append("  "));
     if (stats.size() > 0) results.append(String.format("%14s: ",lastEventTimestampMsg)).append(stats.iterator().next().timestamp());
     return results.toString();
+  }
+
+  public static Collection<Double> currentConsumptionRateByQuery() {
+    return collectorMap.values()
+        .stream()
+        .filter(collector -> collector.getGroupId() != null)
+        .collect(Collectors.groupingBy(MetricCollector::getGroupId,
+                                       Collectors.summingDouble(
+                                           MetricCollector::currentMessageConsumptionRate)))
+        .values();
   }
 
   public static double currentProductionRate() {

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ProducerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ProducerCollector.java
@@ -84,6 +84,7 @@ public class ProducerCollector implements MetricCollector {
     // Note: synchronized due to metrics registry not handling concurrent add/check-exists activity in a reliable way
     synchronized (metrics) {
       addSensor(key, "events-per-sec", new Rate(), sensors, false);
+      addSensor(key, "failed-events-per-sec", new Rate(), sensors, true);
       addSensor(key, "  total-events", new Total(), sensors, false);
       addSensor(key, "  total-failed", new Total(), sensors, true);
     }
@@ -136,6 +137,17 @@ public class ProducerCollector implements MetricCollector {
     return allStats
         .stream()
         .filter(stat -> stat.name().contains("events-per-sec"))
+        .mapToDouble(TopicSensors.Stat::getValue)
+        .sum();
+  }
+
+  @Override
+  public double errorRate() {
+    final List<TopicSensors.Stat> allStats = new ArrayList<>();
+    topicSensors.values().forEach(record -> allStats.addAll(record.errorRateStats()));
+
+    return allStats
+        .stream()
         .mapToDouble(TopicSensors.Stat::getValue)
         .sum();
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -127,6 +127,7 @@ public class KsqlEngine implements Closeable, QueryTerminator {
     aggregateMetricsCollector.scheduleAtFixedRate(() -> {
       engineMetrics.recordMessagesConsumed(MetricCollectors.currentConsumptionRate());
       engineMetrics.recordMessagesProduced(MetricCollectors.currentProductionRate());
+      engineMetrics.recordMessageConsumptionByQueryStats(MetricCollectors.currentConsumptionRateByQuery());
     }, 1000, 1000, TimeUnit.MILLISECONDS);
   }
 
@@ -462,7 +463,6 @@ public class KsqlEngine implements Closeable, QueryTerminator {
     topicClient.close();
     engineMetrics.close();
   }
-
 
   @Override
   public boolean terminateAllQueries() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -29,7 +29,6 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.internal.KsqlEngineMetrics;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetaStoreImpl;
-import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.SqlBaseParser;
@@ -124,11 +123,8 @@ public class KsqlEngine implements Closeable, QueryTerminator {
     this.engineMetrics = new KsqlEngineMetrics("ksql-engine", this);
 
     this.aggregateMetricsCollector = Executors.newSingleThreadScheduledExecutor();
-    aggregateMetricsCollector.scheduleAtFixedRate(() -> {
-      engineMetrics.recordMessagesConsumed(MetricCollectors.currentConsumptionRate());
-      engineMetrics.recordMessagesProduced(MetricCollectors.currentProductionRate());
-      engineMetrics.recordMessageConsumptionByQueryStats(MetricCollectors.currentConsumptionRateByQuery());
-    }, 1000, 1000, TimeUnit.MILLISECONDS);
+    aggregateMetricsCollector.scheduleAtFixedRate(engineMetrics::updateMetrics, 1000, 1000,
+                                                  TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -462,6 +458,7 @@ public class KsqlEngine implements Closeable, QueryTerminator {
     }
     topicClient.close();
     engineMetrics.close();
+    aggregateMetricsCollector.shutdown();
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Min;
 import org.apache.kafka.common.metrics.stats.Value;
 
 import java.io.Closeable;
@@ -104,6 +105,7 @@ public class KsqlEngineMetrics implements Closeable {
   private Sensor configureMessageConsumptionByQuerySensor(Metrics metrics) {
     Sensor sensor = metrics.sensor("message-consumption-by-query");
     sensor.add(metrics.metricName("messages-consumed-max", this.metricGroupName), new Max());
+    sensor.add(metrics.metricName("messages-consumed-min", this.metricGroupName), new Min());
     sensor.add(metrics.metricName("messages-consumed-avg", this.metricGroupName), new Avg());
     return sensor;
   }


### PR DESCRIPTION
This patch builds on #513 and adds metrics the following:
1. idle queries (ie. those which have no data flow)
2. min/max/avg messages-in/s across all queries in the engine. This will give an idea of skew in the data flow.
3. Aggregate error rates across all the queries in the engine.